### PR TITLE
[RCM-33] Add tox support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ services:
 
 before_script:
   - pip install tox
+  - python abell-db-setup.py
 
 script:
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,6 @@ before_script:
   - pip install flake8
   - flake8
 
-script: tox
+script:
+  - tox
+  - python functional_tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
 
 before_script:
   - pip install tox
-  - mongo abell --eval 'use admin; db.createUser({user: "admin", password:"password", roles:["userAdminAnyDatabase"]});'
+  - ./bootstrap_mongodb.sh
   - python abell-db-setup.py
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,11 @@ language: python
 sudo: false
 cache: pip
 
-python:
-  - "3.5"
-
 services:
   - mongodb
 
-before_istall:
+before_script:
   - pip install flake8
   - flake8
 
-install:
-  - pip install -r requirements.txt
-
-script:
-  - python tests.py
+script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+python:
+    - "3.5"
+
 sudo: false
 cache: pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ services:
 
 before_script:
   - pip install tox
+  - mongo abell --eval 'db.addUser("admin", "password");'
   - python abell-db-setup.py
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ cache: pip
 services:
   - mongodb
 
+before_script:
+  - pip install tox
+
 script:
   - tox
   - python functional_tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
 
 before_script:
   - pip install tox
-  - mongo abell --eval 'db.addUser("admin", "password");'
+  - mongo abell --eval 'use admin; db.createUser({user: "admin", password:"password", roles:["userAdminAnyDatabase"]});'
   - python abell-db-setup.py
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ cache: pip
 services:
   - mongodb
 
-before_script:
-  - pip install flake8
-  - flake8
-
 script:
   - tox
   - python functional_tests.py

--- a/abell/api/v1_controller.py
+++ b/abell/api/v1_controller.py
@@ -144,7 +144,6 @@ def return_asset_info():
     Returns:
         Response dict: {'code': int, 'payload': dict, 'details': dict}
     """
-    response_details = {}
     validate_response = validate_data('asset_info', request.args,
                                       ['type'])
     if not validate_response.get('success'):

--- a/abell/database/__init__.py
+++ b/abell/database/__init__.py
@@ -55,9 +55,9 @@ class AbellDb(object):
         response_dict = {'success': False}
         asset_type = initial_keys.get('type')
         try:
-            resp = mongo.db.assetinfo.insert_one(initial_keys)
-            resp = mongo.db.create_collection(asset_type)
-            resp = mongo.db[asset_type].create_index('abell_id', unique=True)
+            mongo.db.assetinfo.insert_one(initial_keys)
+            mongo.db.create_collection(asset_type)
+            mongo.db[asset_type].create_index('abell_id', unique=True)
             response_dict.update({'success': True})
             return response_dict
         except Exception as e:

--- a/abell/models/asset_type.py
+++ b/abell/models/asset_type.py
@@ -1,4 +1,3 @@
-from abell.models import model_tools
 from abell.database import AbellDb
 
 

--- a/bootstrap_mongodb.sh
+++ b/bootstrap_mongodb.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+mongo admin --host 127.0.0.1 --eval 'db.createUser({user:"admin", pwd:"password", roles: [{role:"userAdminAnyDatabase", db: "admin"}]});'

--- a/functional_tests.py
+++ b/functional_tests.py
@@ -116,7 +116,6 @@ class DeleteAssetTypeTestCase(unittest.TestCase):
         self.app_context.pop()
 
     def test_asset_delete_nonexistent(self):
-        a = {'type': 'server'}
         r = self.app.delete('/api/v1/asset_type?type=server')
         self.assertEqual(r.status_code, 404)
 

--- a/setup.py
+++ b/setup.py
@@ -5,4 +5,5 @@ setup(
     description="Centralized configuration storage",
     author="Abell Contributors",
     packages=['abell'],
+    zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,8 @@
+from setuptools import setup
+
+setup(
+    name="abell",
+    description="Centralized configuration storage",
+    author="Abell Contributors",
+    packages=['abell'],
+)

--- a/tests.py
+++ b/tests.py
@@ -1,6 +1,5 @@
 from abell import create_app
 from abell.config import test_config
-from abell.database import AbellDb
 import json
 
 import unittest
@@ -121,13 +120,11 @@ class DeleteAssetTypeTestCase(unittest.TestCase):
         self.app_context.pop()
 
     def test_asset_delete_nonexistent(self):
-        a = {'type': 'server'}
         r = self.app.delete('/api/v1/asset_type?type=server')
         self.assertEqual(r.status_code, 404)
 
     @mock.patch('abell.models.asset_type.get_asset_type')
     def test_asset_delete(self, mock_get):
-        a = {'type': 'server'}
         mock_type = mock.Mock()
         mock_type.remove_type.return_value = {'success': True}
         mock_get.return_value = mock_type
@@ -157,7 +154,7 @@ class UpdateAssetTypeTestCase(unittest.TestCase):
         mock_type.update_keys.return_value = {'success': True,
                                               'removed_keys': ['test'],
                                               'new_keys': []
-                                             }
+                                              }
         mock_get.return_value = mock_type
         u = {'type': 'server',
              'remove_keys': ['test']}
@@ -170,12 +167,11 @@ class UpdateAssetTypeTestCase(unittest.TestCase):
 
     @mock.patch('abell.models.asset_type.AbellAssetType')
     def test_asset_type_swap_keys(self, mock_at):
-        # TODO: This test needs to be revisited; it seems that we should be using PUT
-        # to modify the asset type vs post...
+        # TODO: This test needs to be revisited; it seems that we
+        # should be using PUT to modify the asset type vs post...
         mock_type = mock.Mock()
         mock_type.return_value = mock.Mock()
         mock_type.return_value.create_new_type.return_value = {'success': True}
-        mock_create = mock_type.return_value.create_new_type
         mock_at.return_value = mock_type
         a = {'type': 'server',
              'managed_keys': ['test'],
@@ -194,7 +190,7 @@ class UpdateAssetTypeTestCase(unittest.TestCase):
         mock_type.update_keys.return_value = {'success': True,
                                               'removed_keys': [],
                                               'new_keys': ['test3']
-                                             }
+                                              }
         mock_get.return_value = mock_type
         u = {'type': 'server',
              'managed_keys': ['test3']}

--- a/tox.ini
+++ b/tox.ini
@@ -6,4 +6,7 @@ envlist = py35
 usedevelop = True
 deps =
   -r{toxinidir}/requirements.txt
-commands = python tests.py
+  flake8
+commands =
+  flake8
+  python tests.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+skipdist = True
+envlist = py35
+
+[testenv]
+usedevelop = True
+deps = -r{toxinidir}/requirements.txt
+commands = python tests.py

--- a/tox.ini
+++ b/tox.ini
@@ -4,5 +4,6 @@ envlist = py35
 
 [testenv]
 usedevelop = True
-deps = -r{toxinidir}/requirements.txt
+deps =
+  -r{toxinidir}/requirements.txt
 commands = python tests.py


### PR DESCRIPTION
Using tox allows us to test the code locally, using the same tools that
Travis does. This is preferrable to setting everything up by hand.